### PR TITLE
Parsing gosecure calls in main

### DIFF
--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -725,6 +725,7 @@ func (s *SendStmt) Pos() token.Pos       { return s.Chan.Pos() }
 func (s *IncDecStmt) Pos() token.Pos     { return s.X.Pos() }
 func (s *AssignStmt) Pos() token.Pos     { return s.Lhs[0].Pos() }
 func (s *GoStmt) Pos() token.Pos         { return s.Go }
+func (s *GosecStmt) Pos() token.Pos      { return s.Gosecure }
 func (s *DeferStmt) Pos() token.Pos      { return s.Defer }
 func (s *ReturnStmt) Pos() token.Pos     { return s.Return }
 func (s *BranchStmt) Pos() token.Pos     { return s.TokPos }
@@ -754,6 +755,7 @@ func (s *IncDecStmt) End() token.Pos {
 }
 func (s *AssignStmt) End() token.Pos { return s.Rhs[len(s.Rhs)-1].End() }
 func (s *GoStmt) End() token.Pos     { return s.Call.End() }
+func (s *GosecStmt) End() token.Pos  { return s.Call.End() }
 func (s *DeferStmt) End() token.Pos  { return s.Call.End() }
 func (s *ReturnStmt) End() token.Pos {
 	if n := len(s.Results); n > 0 {
@@ -804,6 +806,7 @@ func (*SendStmt) stmtNode()       {}
 func (*IncDecStmt) stmtNode()     {}
 func (*AssignStmt) stmtNode()     {}
 func (*GoStmt) stmtNode()         {}
+func (*GosecStmt) stmtNode()      {}
 func (*DeferStmt) stmtNode()      {}
 func (*ReturnStmt) stmtNode()     {}
 func (*BranchStmt) stmtNode()     {}
@@ -995,6 +998,7 @@ type File struct {
 	Imports    []*ImportSpec   // imports in this file
 	Unresolved []*Ident        // unresolved identifiers in this file
 	Comments   []*CommentGroup // list of all comments in the source file
+	GosecCalls []*GosecStmt    //@aghosn holds the gosecure call nodes
 }
 
 func (f *File) Pos() token.Pos { return f.Package }

--- a/src/go/ast/filter.go
+++ b/src/go/ast/filter.go
@@ -461,5 +461,5 @@ func MergePackageFiles(pkg *Package, mode MergeMode) *File {
 	}
 
 	// TODO(gri) need to compute unresolved identifiers!
-	return &File{doc, pos, NewIdent(pkg.Name), decls, pkg.Scope, imports, nil, comments}
+	return &File{doc, pos, NewIdent(pkg.Name), decls, pkg.Scope, imports, nil, comments, nil}
 }

--- a/src/go/parser/gosecparser.go
+++ b/src/go/parser/gosecparser.go
@@ -1,0 +1,33 @@
+package parser
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// parseGosecCalls returns the stmt that contain the gosecure keyword.
+// These are then stored in the File describing the package.
+// We reload the source which is not efficient, but avoids modifying too much
+// of the existing code.
+// This function panics if called on a package that is not main.
+func parseGosecCalls(fset *token.FileSet, filename string) (s []*ast.GosecStmt) {
+	bytes, err := readSource(filename, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	var p parser
+
+	p.init(fset, filename, bytes, ImportsOnly|ParseComments)
+
+	for p.tok != token.EOF {
+		if p.tok == token.GOSEC {
+			a := p.parseGosecStmt().(*ast.GosecStmt)
+			s = append(s, a)
+		} else {
+			p.next()
+		}
+	}
+
+	return
+}

--- a/src/go/parser/interface.go
+++ b/src/go/parser/interface.go
@@ -120,6 +120,10 @@ func ParseFile(fset *token.FileSet, filename string, src interface{}, mode Mode)
 	p.init(fset, filename, text, mode)
 	f = p.parseFile()
 
+	if f.Name != nil && f.Name.Name == "main" {
+		f.GosecCalls = parseGosecCalls(fset, filename)
+	}
+
 	return
 }
 

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -2175,6 +2175,8 @@ func (p *parser) parseStmt() (s ast.Stmt) {
 		}
 	case token.GO:
 		s = p.parseGoStmt()
+	case token.GOSEC:
+		s = p.parseGosecStmt()
 	case token.DEFER:
 		s = p.parseDeferStmt()
 	case token.RETURN:
@@ -2443,6 +2445,23 @@ func (p *parser) parseDecl(sync func(*parser)) ast.Decl {
 	}
 
 	return p.parseGenDecl(p.tok, f)
+}
+
+// ----------------------------------------------------------------------------
+// Gosecure related parsing.
+
+// parseGoSecureCalls finds all the stmt that have a gosecure call.
+func (p *parser) parseGosecStmt() ast.Stmt {
+	if p.trace {
+		defer un(trace(p, "GosecureStmt"))
+	}
+	pos := p.expect(token.GOSEC)
+	call := p.parseCallExpr("gosecure")
+	p.expectSemi()
+	if call == nil {
+		return &ast.BadStmt{From: pos, To: pos + 8} // len("gosecure")
+	}
+	return &ast.GosecStmt{Gosecure: pos, Call: call}
 }
 
 // ----------------------------------------------------------------------------

--- a/src/go/token/token.go
+++ b/src/go/token/token.go
@@ -207,7 +207,7 @@ var tokens = [...]string{
 
 	FUNC:   "func",
 	GO:     "go",
-	GOSEC:  "gosec",
+	GOSEC:  "gosecure",
 	GOTO:   "goto",
 	IF:     "if",
 	IMPORT: "import",


### PR DESCRIPTION
For the moment we only allow gosecure in the main package.
These calls are parsed so as to register the callee and build a list of
targets that will be used to extract function bodies when parsing
external packages.

