### PR TITLE
Runtime cooperative channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,4 @@ gooey:
 clean:
 	@sh clean.sh
 	@rm -f _run.sh
+

--- a/src/cmd/compile/internal/gc/ssa.go
+++ b/src/cmd/compile/internal/gc/ssa.go
@@ -3223,7 +3223,7 @@ func (s *state) call(n *Node, k callKind) *ssa.Value {
 		s.vars[&memVar] = s.newValue3A(ssa.OpStore, types.TypeMem, types.Types[TUINTPTR], addr, rcvr, s.mem())
 	}
 
-	// Defer/go args
+	// Defer/go/gosecure args
 	if k != callNormal {
 		// Write argsize and closure (args to Newproc/Deferproc).
 		argStart := Ctxt.FixedFrameSize()
@@ -3231,6 +3231,7 @@ func (s *state) call(n *Node, k callKind) *ssa.Value {
 		addr := s.constOffPtrSP(s.f.Config.Types.UInt32Ptr, argStart)
 		s.vars[&memVar] = s.newValue3A(ssa.OpStore, types.TypeMem, types.Types[TUINT32], addr, argsize, s.mem())
 		addr = s.constOffPtrSP(s.f.Config.Types.UintptrPtr, argStart+int64(Widthptr))
+		//TODO @aghosn here we can pass the shitty shit to gosecure. Write an ID instead?
 		s.vars[&memVar] = s.newValue3A(ssa.OpStore, types.TypeMem, types.Types[TUINTPTR], addr, closure, s.mem())
 		stksize += 2 * int64(Widthptr)
 	}

--- a/src/cmd/go/internal/work/gosec.go
+++ b/src/cmd/go/internal/work/gosec.go
@@ -36,10 +36,10 @@ func main() {
 	go __ff()
 	{{range .Functions}}
 
-	gosec.RegisterSecureFunction2({{ . }})
+	gosec.RegisterSecureFunction({{ . }})
 
 	{{end}}
-	gosec.EcallServer2()
+	gosec.EcallServer()
 }
 `
 )

--- a/src/cmd/go/internal/work/gosec.go
+++ b/src/cmd/go/internal/work/gosec.go
@@ -18,23 +18,22 @@ const (
 package main
 
 import(
-	"sync"
+	"gosec"
 	{{range .Imports}}
 	{{ printf "%q" . }}{{end}}
 )
 
 func main() {
-	var wg sync.WaitGroup
 	// Starting the functions.
 	{{range .Functions}}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		{{ . }}()
+	func() {
+		gosec.RegisterSecureFunction({{ . }})
 	}()
-	{{end}}
 
-	wg.Wait()
+	//go {{ . }}()
+	{{end}}
+	go func() {for{}}()
+	gosec.EcallServer()
 }
 `
 )

--- a/src/cmd/go/internal/work/gosec.go
+++ b/src/cmd/go/internal/work/gosec.go
@@ -32,7 +32,6 @@ func main() {
 
 	//go {{ . }}()
 	{{end}}
-	go func() {for{}}()
 	gosec.EcallServer()
 }
 `

--- a/src/cmd/go/internal/work/gosec.go
+++ b/src/cmd/go/internal/work/gosec.go
@@ -35,13 +35,11 @@ func main() {
 
 	go __ff()
 	{{range .Functions}}
-	func() {
-		gosec.RegisterSecureFunction({{ . }})
-	}()
 
-	//go {{ . }}()
+	gosec.RegisterSecureFunction2({{ . }})
+
 	{{end}}
-	gosec.EcallServer()
+	gosec.EcallServer2()
 }
 `
 )

--- a/src/cmd/go/internal/work/gosec.go
+++ b/src/cmd/go/internal/work/gosec.go
@@ -19,12 +19,21 @@ package main
 
 import(
 	"gosec"
+	"runtime"
 	{{range .Imports}}
 	{{ printf "%q" . }}{{end}}
 )
 
+func __ff() {
+	for {
+		runtime.Gosched()
+	}
+}
+
 func main() {
 	// Starting the functions.
+
+	go __ff()
 	{{range .Functions}}
 	func() {
 		gosec.RegisterSecureFunction({{ . }})

--- a/src/gosec/enclEnv.go
+++ b/src/gosec/enclEnv.go
@@ -1,12 +1,16 @@
 package gosec
 
 import (
+	"log"
 	"reflect"
 	"runtime"
+	"unsafe"
 )
 
 // Slice of gosecure targets.
 var gosecFunctions []interface{}
+
+var secureMap map[string]func(size int32, argp *uint8)
 
 // EcallServer keeps polling the Cooprt.Ecall queue for incoming gosecure calls.
 // We cannot use reflect to get the value of the arguments. Instead, we need to
@@ -26,9 +30,46 @@ func EcallServer() {
 	}
 }
 
+func EcallServer2() {
+	for {
+		call := <-runtime.Cooprt.Ecall2
+		//TODO here create the buffer of memory that will be used for the call.
+		//We need to carefully copy the content and replace the function pointer.
+		if fn := secureMap[call.Name]; fn != nil {
+			log.Println("Making a call: ", call.Name, "argp is at", call.Argp)
+			a := (*int)(unsafe.Pointer(call.Argp))
+			log.Println("The value there ", *a)
+			fn(call.Siz, call.Argp)
+		} else {
+			log.Fatalln("Unable to find secure func ", call.Name)
+		}
+	}
+}
+
 // RegisterSecureFunction is called automatically at the begining of the enclave
 // execution, and registers all the functions that are a target of the gosecure
 // keyword.
 func RegisterSecureFunction(f interface{}) {
 	gosecFunctions = append(gosecFunctions, f)
+}
+
+// RegisterSecureFunction is called automatically at the begining of the enclave
+// execution, and registers all the functions that are a target of the gosecure
+// keyword.
+func RegisterSecureFunction2(f interface{}) {
+	if secureMap == nil {
+		secureMap = make(map[string]func(size int32, argp *uint8))
+	}
+
+	ptr := reflect.ValueOf(f).Pointer()
+	pc := runtime.FuncForPC(ptr)
+	if pc == nil {
+		log.Fatalln("Unable to register secure function.")
+	}
+
+	//TODO @aghosn that will not be enough probably. Should have a pointer instead?
+	// or copy memory in a buffer inside the anonymous function?
+	secureMap[pc.Name()] = func(size int32, argp *uint8) {
+		runtime.Newproc(ptr, argp, size)
+	}
 }

--- a/src/gosec/enclEnv.go
+++ b/src/gosec/enclEnv.go
@@ -1,0 +1,36 @@
+package gosec
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+)
+
+// Slice of gosecure targets.
+var gosecFunctions []interface{}
+
+// EcallServer keeps polling the Cooprt.Ecall queue for incoming gosecure calls.
+// We cannot use reflect to get the value of the arguments. Instead, we need to
+// create an equivalent type by going through unsafe.Pointer and type casting.
+func EcallServer() {
+	for {
+		call := <-runtime.Cooprt.Ecall
+		fn := reflect.ValueOf(gosecFunctions[call.Id])
+		tpes := reflect.TypeOf(gosecFunctions[call.Id])
+		var args []reflect.Value
+		for i := range call.Args {
+			ptr := call.Args[i]
+			val := (reflect.NewAt(tpes.In(i), ptr)).Elem()
+			fmt.Printf("The shit shit %v\n", val)
+			args = append(args, val)
+		}
+		go fn.Call(args)
+	}
+}
+
+// RegisterSecureFunction is called automatically at the begining of the enclave
+// execution, and registers all the functions that are a target of the gosecure
+// keyword.
+func RegisterSecureFunction(f interface{}) {
+	gosecFunctions = append(gosecFunctions, f)
+}

--- a/src/gosec/enclEnv.go
+++ b/src/gosec/enclEnv.go
@@ -1,7 +1,6 @@
 package gosec
 
 import (
-	"fmt"
 	"reflect"
 	"runtime"
 )
@@ -21,7 +20,6 @@ func EcallServer() {
 		for i := range call.Args {
 			ptr := call.Args[i]
 			val := (reflect.NewAt(tpes.In(i), ptr)).Elem()
-			fmt.Printf("The shit shit %v\n", val)
 			args = append(args, val)
 		}
 		go fn.Call(args)

--- a/src/gosec/enclEnv.go
+++ b/src/gosec/enclEnv.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"reflect"
 	"runtime"
-	"unsafe"
 )
 
 // Slice of gosecure targets.
@@ -36,9 +35,6 @@ func EcallServer2() {
 		//TODO here create the buffer of memory that will be used for the call.
 		//We need to carefully copy the content and replace the function pointer.
 		if fn := secureMap[call.Name]; fn != nil {
-			log.Println("Making a call: ", call.Name, "argp is at", call.Argp)
-			a := (*int)(unsafe.Pointer(call.Argp))
-			log.Println("The value there ", *a)
 			fn(call.Siz, call.Argp)
 		} else {
 			log.Fatalln("Unable to find secure func ", call.Name)

--- a/src/gosec/enclEnv.go
+++ b/src/gosec/enclEnv.go
@@ -7,31 +7,15 @@ import (
 )
 
 // Slice of gosecure targets.
-var gosecFunctions []interface{}
-
 var secureMap map[string]func(size int32, argp *uint8)
 
 // EcallServer keeps polling the Cooprt.Ecall queue for incoming gosecure calls.
-// We cannot use reflect to get the value of the arguments. Instead, we need to
-// create an equivalent type by going through unsafe.Pointer and type casting.
+// We cannot use reflect to get the value of the arguments. Instead, we give
+// a pointer to a buffer allocated inside the ecall attribute and use it to pass
+// the arguments from the stack frame.
 func EcallServer() {
 	for {
 		call := <-runtime.Cooprt.Ecall
-		fn := reflect.ValueOf(gosecFunctions[call.Id])
-		tpes := reflect.TypeOf(gosecFunctions[call.Id])
-		var args []reflect.Value
-		for i := range call.Args {
-			ptr := call.Args[i]
-			val := (reflect.NewAt(tpes.In(i), ptr)).Elem()
-			args = append(args, val)
-		}
-		go fn.Call(args)
-	}
-}
-
-func EcallServer2() {
-	for {
-		call := <-runtime.Cooprt.Ecall2
 		//TODO here create the buffer of memory that will be used for the call.
 		//We need to carefully copy the content and replace the function pointer.
 		if fn := secureMap[call.Name]; fn != nil {
@@ -46,13 +30,6 @@ func EcallServer2() {
 // execution, and registers all the functions that are a target of the gosecure
 // keyword.
 func RegisterSecureFunction(f interface{}) {
-	gosecFunctions = append(gosecFunctions, f)
-}
-
-// RegisterSecureFunction is called automatically at the begining of the enclave
-// execution, and registers all the functions that are a target of the gosecure
-// keyword.
-func RegisterSecureFunction2(f interface{}) {
 	if secureMap == nil {
 		secureMap = make(map[string]func(size int32, argp *uint8))
 	}

--- a/src/gosec/internal.go
+++ b/src/gosec/internal.go
@@ -94,7 +94,7 @@ func Gosecload(size int32, fn *funcval, b uint8) {
 		LoadEnclave()
 	}
 	//Copy the stack frame inside a buffer.
-	attrib := runtime.EcallAttr2{}
+	attrib := runtime.EcallAttr{}
 	attrib.Name, attrib.Siz = pc.Name(), size
 	attrib.Buf, attrib.Argp = nil, nil
 	if size > 0 {
@@ -103,5 +103,5 @@ func Gosecload(size int32, fn *funcval, b uint8) {
 		attrib.Argp = (*uint8)(unsafe.Pointer(&(attrib.Buf[0])))
 	}
 
-	runtime.Cooprt.Ecall2 <- attrib
+	runtime.Cooprt.Ecall <- attrib
 }

--- a/src/gosec/sim.go
+++ b/src/gosec/sim.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"runtime"
 	"syscall"
-	"time"
 	"unsafe"
 )
 
@@ -44,7 +43,6 @@ func loadProgram(path string) {
 
 	//fn := unsafe.Pointer(uintptr(0x1879e0))
 	runtime.AllocateOSThreadEncl(addr+uintptr(size), fn)
-	time.Sleep(10)
 }
 
 func mapSections(secs []*elf.Section) {

--- a/src/runtime/asm_amd64.s
+++ b/src/runtime/asm_amd64.s
@@ -8,7 +8,7 @@
 #include "textflag.h"
 
 // _encl0_amd64 is a startup code for amd64 enclave code.
-// The goal here is to put a 0 inside the argc to let the runtime know we are
+// The goal here is to put a -1 inside the argc to let the runtime know we are
 // in an enclave.
 TEXT _encl0_amd64(SB),NOSPLIT,$-8
 	MOVQ	$-1, DI		//argc for enclave
@@ -100,7 +100,7 @@ TEXT runtime·rt0_go(SB),NOSPLIT,$0
 	ANDQ	$~15, SP
 	MOVQ	AX, 16(SP)
 	MOVQ	BX, 24(SP)
-	
+
 	// create istack out of the given (operating system) stack.
 	// _cgo_init may update stackguard.
 	MOVQ	$runtime·g0(SB), DI
@@ -345,7 +345,7 @@ nilctxt:
 // to keep running g.
 TEXT runtime·mcall(SB), NOSPLIT, $0-8
 	MOVQ	fn+0(FP), DI
-	
+
 	get_tls(CX)
 	MOVQ	g(CX), AX	// save state in g->sched
 	MOVQ	0(SP), BX	// caller's PC
@@ -400,7 +400,7 @@ TEXT runtime·systemstack(SB), NOSPLIT, $0-8
 	MOVQ	m_curg(BX), R8
 	CMPQ	AX, R8
 	JEQ	switch
-	
+
 	// Bad: g is not gsignal, not g0, not curg. What is it?
 	MOVQ	$runtime·badsystemstack(SB), AX
 	CALL	AX
@@ -688,7 +688,7 @@ TEXT ·asmcgocall(SB),NOSPLIT,$0-20
 	MOVQ	m_gsignal(R8), SI
 	CMPQ	SI, DI
 	JEQ	nosave
-	
+
 	// Switch to system stack.
 	MOVQ	m_g0(R8), SI
 	CALL	gosave<>(SB)
@@ -788,7 +788,7 @@ needm:
 	get_tls(CX)
 	MOVQ	g(CX), BX
 	MOVQ	g_m(BX), BX
-	
+
 	// Set m->sched.sp = SP, so that if a panic happens
 	// during the function we are about to execute, it will
 	// have a valid SP to run on the g0 stack.
@@ -872,7 +872,7 @@ havem:
 	MOVQ	(g_sched+gobuf_sp)(SI), SP
 	MOVQ	0(SP), AX
 	MOVQ	AX, (g_sched+gobuf_sp)(SI)
-	
+
 	// If the m on entry was nil, we called needm above to borrow an m
 	// for the duration of the call. Since the call is over, return it with dropm.
 	CMPQ	R8, $0
@@ -1016,7 +1016,7 @@ aes17to32:
 	// make second starting seed
 	PXOR	runtime·aeskeysched+16(SB), X1
 	AESENC	X1, X1
-	
+
 	// load data to be hashed
 	MOVOU	(AX), X2
 	MOVOU	-16(AX)(CX*1), X3
@@ -1048,7 +1048,7 @@ aes33to64:
 	AESENC	X1, X1
 	AESENC	X2, X2
 	AESENC	X3, X3
-	
+
 	MOVOU	(AX), X4
 	MOVOU	16(AX), X5
 	MOVOU	-32(AX)(CX*1), X6
@@ -1058,17 +1058,17 @@ aes33to64:
 	PXOR	X1, X5
 	PXOR	X2, X6
 	PXOR	X3, X7
-	
+
 	AESENC	X4, X4
 	AESENC	X5, X5
 	AESENC	X6, X6
 	AESENC	X7, X7
-	
+
 	AESENC	X4, X4
 	AESENC	X5, X5
 	AESENC	X6, X6
 	AESENC	X7, X7
-	
+
 	AESENC	X4, X4
 	AESENC	X5, X5
 	AESENC	X6, X6
@@ -1184,7 +1184,7 @@ aes129plus:
 	AESENC	X5, X5
 	AESENC	X6, X6
 	AESENC	X7, X7
-	
+
 	// start with last (possibly overlapping) block
 	MOVOU	-128(AX)(CX*1), X8
 	MOVOU	-112(AX)(CX*1), X9
@@ -1204,11 +1204,11 @@ aes129plus:
 	PXOR	X5, X13
 	PXOR	X6, X14
 	PXOR	X7, X15
-	
+
 	// compute number of remaining 128-byte blocks
 	DECQ	CX
 	SHRQ	$7, CX
-	
+
 aesloop:
 	// scramble state
 	AESENC	X8, X8
@@ -1277,7 +1277,7 @@ aesloop:
 	PXOR	X9, X8
 	MOVQ	X8, (DX)
 	RET
-	
+
 TEXT runtime·aeshash32(SB),NOSPLIT,$0-24
 	MOVQ	p+0(FP), AX	// ptr to data
 	MOVQ	h+8(FP), X0	// seed
@@ -1416,7 +1416,7 @@ TEXT runtime·memeqbody(SB),NOSPLIT,$0-0
 	JB	bigloop
 	CMPB    runtime·support_avx2(SB), $1
 	JE	hugeloop_avx2
-	
+
 	// 64 bytes at a time using xmm registers
 hugeloop:
 	CMPQ	BX, $64
@@ -1575,7 +1575,7 @@ loop:
 	ADDQ	$16, DI
 	SUBQ	$16, R8
 	JMP	loop
-	
+
 diff64:
 	ADDQ	$48, SI
 	ADDQ	$48, DI
@@ -2043,7 +2043,7 @@ TEXT runtime·indexbytebody(SB),NOSPLIT,$0
 	PUNPCKLBW X0, X0
 	PUNPCKLBW X0, X0
 	PSHUFL $0, X0, X0
-	
+
 	CMPQ BX, $16
 	JLT small
 
@@ -2054,7 +2054,7 @@ TEXT runtime·indexbytebody(SB),NOSPLIT,$0
 sse:
 	LEAQ	-16(SI)(BX*1), AX	// AX = address of last 16 bytes
 	JMP	sseloopentry
-	
+
 sseloop:
 	// Move the next 16-byte chunk of the data into X1.
 	MOVOU	(DI), X1

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -226,6 +226,9 @@ func chansend(c *hchan, ep unsafe.Pointer, block bool, callerpc uintptr) bool {
 		// Blocking on a send from enclave.
 		// take a sudog from the free list and use it.
 		mysg = acquireSudogFromPool()
+		if !gp.isencl || !isEnclave {
+			panic("Acquiring sudog from the pool in wrong environment.")
+		}
 	} else {
 		mysg = acquireSudog()
 	}
@@ -305,7 +308,6 @@ func send(c *hchan, sg *sudog, ep unsafe.Pointer, unlockf func(), skip int) {
 		if sg.releasetime != 0 {
 			sg.releasetime = cputicks()
 		}
-		print("from send")
 		Cooprt.crossGoready(sg)
 		return
 	}

--- a/src/runtime/chan.go
+++ b/src/runtime/chan.go
@@ -56,30 +56,6 @@ type waitq struct {
 	last  *sudog
 }
 
-// checkinterdomain detects inter domain crossing and panics is trusted struct
-// is referenced from untrusted (sanity check, this will just err with sgx).
-func checkinterdomain(gb, og bool) bool {
-	if !gb && og {
-		panic("An untrusted routine is trying to access a trusted channel")
-	}
-	return gb != og
-}
-
-func acquireSudogFromPool() *sudog {
-	//TODO @aghosn do that atomically
-	for i, x := range Cooprt.pool {
-		if x.available != 0 {
-			x.available = 0
-			x.wg.id = int32(i)
-			x.isencl = isEnclave
-			return x.wg
-		}
-	}
-	//TODO @aghosn should come up with something here.
-	panic("Ran out of sudog in the pool.")
-	return nil
-}
-
 //go:linkname reflect_makechan reflect.makechan
 func reflect_makechan(t *chantype, size int) *hchan {
 	return makechan(t, size)
@@ -287,7 +263,8 @@ func chansend(c *hchan, ep unsafe.Pointer, block bool, callerpc uintptr) bool {
 		blockevent(mysg.releasetime-t0, 2)
 	}
 	mysg.c = nil
-	releaseSudog(mysg)
+
+	crossReleaseSudog(mysg)
 	return true
 }
 
@@ -321,17 +298,18 @@ func send(c *hchan, sg *sudog, ep unsafe.Pointer, unlockf func(), skip int) {
 		sendDirect(c.elemtype, sg, ep)
 		sg.elem = nil
 	}
-	//TODO @aghosn here need to check what type of sg it is.
-	// If it has an id, it means it comes from a pool.
-	//Wait, if we are in the same domain it should be fine to reschedule directly.
-	// So makeready should actually return something to know if we skip or not.
-	if sg.id != -1 && !Cooprt.tryGoReady(sg) {
+
+	if !isReschedulable(sg) {
+		//TODO @aghosn don't know what to do with the gp.param.
 		unlockf()
 		if sg.releasetime != 0 {
 			sg.releasetime = cputicks()
 		}
+		print("from send")
+		Cooprt.crossGoready(sg)
 		return
 	}
+
 	gp := sg.g
 	unlockf()
 	gp.param = unsafe.Pointer(sg)
@@ -586,7 +564,8 @@ func chanrecv(c *hchan, ep unsafe.Pointer, block bool) (selected, received bool)
 	closed := gp.param == nil
 	gp.param = nil
 	mysg.c = nil
-	releaseSudog(mysg)
+
+	crossReleaseSudog(mysg)
 	return true, !closed
 }
 
@@ -637,22 +616,21 @@ func recv(c *hchan, sg *sudog, ep unsafe.Pointer, unlockf func(), skip int) {
 		c.sendx = c.recvx // c.sendx = (c.sendx+1) % c.dataqsiz
 	}
 	sg.elem = nil
-	if sg.id != -1 && !Cooprt.tryGoReady(sg) {
+	if !isReschedulable(sg) {
+		//TODO @aghosn don't know what to do with gp.param
 		unlockf()
 		if sg.releasetime != 0 {
 			sg.releasetime = cputicks()
 		}
+		Cooprt.crossGoready(sg)
 		return
 	}
+
 	gp := sg.g
 	unlockf()
 	gp.param = unsafe.Pointer(sg)
 	if sg.releasetime != 0 {
 		sg.releasetime = cputicks()
-	}
-	if sg.id != -1 {
-		//TODO @aghosn special case here.
-		// use the isencl from g to put it in the correct queue.
 	}
 	goready(gp, skip+1)
 }

--- a/src/runtime/gosec.go
+++ b/src/runtime/gosec.go
@@ -13,6 +13,7 @@ type EcallAttr2 struct {
 	Name string
 	Siz  int32
 	Argp *uint8 //TODO @aghosn not sure about this one.
+	Buf  []uint8
 }
 
 type poolSudog struct {

--- a/src/runtime/gosec.go
+++ b/src/runtime/gosec.go
@@ -4,6 +4,17 @@ import (
 	"unsafe"
 )
 
+type ECallAttr struct {
+	Id   int32
+	Args []unsafe.Pointer
+}
+
+type CooperativeRuntime struct {
+	Ecall chan ECallAttr
+	argc  int32
+	argv  **byte
+}
+
 func AllocateOSThreadEncl(stack uintptr, fn unsafe.Pointer) {
 	//if secp != nil {
 	//	throw("secp is already allocated.\n")
@@ -15,15 +26,15 @@ func AllocateOSThreadEncl(stack uintptr, fn unsafe.Pointer) {
 	ptrArgc := (*int32)(unsafe.Pointer(addrArgc))
 	*ptrArgc = argc
 
+	Cooprt = &CooperativeRuntime{make(chan ECallAttr), -1, argv}
 	ptrArgv := (***byte)(unsafe.Pointer(addrArgv))
-	*ptrArgv = argv
+	*ptrArgv = (**byte)(unsafe.Pointer(Cooprt))
 
 	ret := clone(cloneFlags, unsafe.Pointer(addrArgv), nil, nil, fn)
 	if ret < 0 {
 		write(2, unsafe.Pointer(&failthreadcreate[0]), int32(len(failthreadcreate)))
 		exit(1)
 	}
-
 }
 
 func Newproc(siz int32, ptr uintptr) {

--- a/src/runtime/gosec.go
+++ b/src/runtime/gosec.go
@@ -9,10 +9,42 @@ type ECallAttr struct {
 	Args []unsafe.Pointer
 }
 
+type poolSudog struct {
+	available int
+	wg        *sudog
+	isencl    bool
+}
+
 type CooperativeRuntime struct {
 	Ecall chan ECallAttr
 	argc  int32
 	argv  **byte
+
+	//TODO @aghosn need a lock here. Mutex should be enough
+	// but might need to avoid futex call? Should only happen when last goroutine
+	// goes to sleep, right?
+	etoo *sudog //Blocked TODO @aghosn might need pointer to chan?
+	otoe *sudog
+
+	readyE waitq //Ready to be rescheduled
+	readyO waitq
+
+	pool [50]poolSudog //TODO @aghosn pool of sudog structs allocated in non-trusted.
+}
+
+func (c *CooperativeRuntime) tryGoReady(sg *sudog) bool {
+	// Can we treat it as same domain. If so, use the go channel regular code.
+	// TODO @aghosn do not forget to modify  goready
+	if c.pool[sg.id].isencl == isEnclave {
+		return true
+	}
+	// Do not release the sudog yet. This will be done when we reschedule g.
+	if c.pool[sg.id].isencl {
+		c.readyE.enqueue(sg)
+	} else {
+		c.readyO.enqueue(sg)
+	}
+	return false
 }
 
 func AllocateOSThreadEncl(stack uintptr, fn unsafe.Pointer) {
@@ -26,7 +58,18 @@ func AllocateOSThreadEncl(stack uintptr, fn unsafe.Pointer) {
 	ptrArgc := (*int32)(unsafe.Pointer(addrArgc))
 	*ptrArgc = argc
 
-	Cooprt = &CooperativeRuntime{make(chan ECallAttr), -1, argv}
+	// Initialize the Cooprt
+	Cooprt = &CooperativeRuntime{}
+	Cooprt.Ecall, Cooprt.argc, Cooprt.argv = make(chan ECallAttr), -1, argv
+	Cooprt.etoo, Cooprt.otoe = nil, nil
+	//Cooprt.readyE, Cooprt.readyO = nil, nil
+	for i := range Cooprt.pool {
+		Cooprt.pool[i].wg = &sudog{}
+		Cooprt.pool[i].wg.id = int32(i)
+		Cooprt.pool[i].available = 1
+		Cooprt.pool[i].isencl = false
+	}
+
 	ptrArgv := (***byte)(unsafe.Pointer(addrArgv))
 	*ptrArgv = (**byte)(unsafe.Pointer(Cooprt))
 

--- a/src/runtime/gosec.go
+++ b/src/runtime/gosec.go
@@ -4,12 +4,7 @@ import (
 	"unsafe"
 )
 
-type ECallAttr struct {
-	Id   int32
-	Args []unsafe.Pointer
-}
-
-type EcallAttr2 struct {
+type EcallAttr struct {
 	Name string
 	Siz  int32
 	Argp *uint8 //TODO @aghosn not sure about this one.
@@ -23,10 +18,9 @@ type poolSudog struct {
 }
 
 type CooperativeRuntime struct {
-	Ecall  chan ECallAttr
-	Ecall2 chan EcallAttr2
-	argc   int32
-	argv   **byte
+	Ecall chan EcallAttr
+	argc  int32
+	argv  **byte
 
 	//TODO @aghosn need a lock here. Mutex should be enough
 	// but might need to avoid futex call? Should only happen when last goroutine
@@ -87,8 +81,7 @@ func AllocateOSThreadEncl(stack uintptr, fn unsafe.Pointer) {
 
 	// Initialize the Cooprt
 	Cooprt = &CooperativeRuntime{}
-	Cooprt.Ecall, Cooprt.argc, Cooprt.argv = make(chan ECallAttr), -1, argv
-	Cooprt.Ecall2 = make(chan EcallAttr2)
+	Cooprt.Ecall, Cooprt.argc, Cooprt.argv = make(chan EcallAttr), -1, argv
 	for i := range Cooprt.pool {
 		Cooprt.pool[i].wg = &sudog{}
 		Cooprt.pool[i].wg.id = int32(i)

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -341,6 +341,9 @@ func acquireSudog() *sudog {
 
 //go:nosplit
 func releaseSudog(s *sudog) {
+	if s.id != -1 {
+		throw("runtime: sudog from pool released.")
+	}
 	if s.elem != nil {
 		throw("runtime: sudog with non-nil elem")
 	}

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -3188,6 +3188,7 @@ func malg(stacksize int32) *g {
 		newg.stackguard0 = newg.stack.lo + _StackGuard
 		newg.stackguard1 = ^uintptr(0)
 	}
+	newg.isencl = isEnclave
 	return newg
 }
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -2582,11 +2582,8 @@ func park_m(gp *g) {
 		}
 	}
 
-	//@aghosn check for crossdomain routines.
-	lock(&sched.lock)
+	//TODO @aghosn check for crossdomain routines.
 	migrateCrossDomain()
-	unlock(&sched.lock)
-
 	schedule()
 }
 
@@ -2598,8 +2595,8 @@ func goschedImpl(gp *g) {
 	}
 	casgstatus(gp, _Grunning, _Grunnable)
 	dropg()
-	lock(&sched.lock)
 	migrateCrossDomain()
+	lock(&sched.lock)
 	globrunqput(gp)
 	unlock(&sched.lock)
 

--- a/src/runtime/proc.go
+++ b/src/runtime/proc.go
@@ -334,6 +334,7 @@ func acquireSudog() *sudog {
 	if s.elem != nil {
 		throw("acquireSudog: found s.elem != nil in cache")
 	}
+	s.id = -1
 	releasem(mp)
 	return s
 }

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -47,8 +47,9 @@ func gotraceback() (level int32, all, crash bool) {
 }
 
 var (
-	argc int32
-	argv **byte
+	argc   int32
+	argv   **byte
+	Cooprt *CooperativeRuntime
 )
 
 // nosplit for use in linux startup sysargs
@@ -63,7 +64,8 @@ func args(c int32, v **byte) {
 	if c == -1 {
 		isEnclave = true
 		ptrArgv := (***byte)(unsafe.Pointer(v))
-		argv = *ptrArgv
+		Cooprt = (*CooperativeRuntime)(unsafe.Pointer((*ptrArgv)))
+		argv = Cooprt.argv
 		argc = 1
 		c = argc
 		v = argv

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -395,6 +395,8 @@ type g struct {
 	// and check for debt in the malloc hot path. The assist ratio
 	// determines how this corresponds to scan work debt.
 	gcAssistBytes int64
+
+	isencl bool
 }
 
 type m struct {

--- a/src/runtime/runtime2.go
+++ b/src/runtime/runtime2.go
@@ -299,6 +299,7 @@ type sudog struct {
 	// For semaphores, all fields (including the ones above)
 	// are only accessed when holding a semaRoot lock.
 
+	id          int32 //TODO @aghosn id in the pool (-1) if does not apply
 	acquiretime int64
 	releasetime int64
 	ticket      uint32

--- a/src/runtime/secspinlock.go
+++ b/src/runtime/secspinlock.go
@@ -1,0 +1,23 @@
+package runtime
+
+import (
+	"runtime/internal/atomic"
+)
+
+type secspinlock struct {
+	f uint32
+}
+
+func (sl *secspinlock) Lock() {
+	for !sl.TryLock() {
+		//osyield()
+	}
+}
+
+func (sl *secspinlock) TryLock() bool {
+	return atomic.Cas(&(sl.f), 0, 1)
+}
+
+func (sl *secspinlock) Unlock() {
+	atomic.Cas(&(sl.f), 1, 0)
+}

--- a/src/runtime/signal_unix.go
+++ b/src/runtime/signal_unix.go
@@ -82,6 +82,10 @@ func initsig(preinit bool) {
 		signalsOK = true
 	}
 
+	if isEnclave && !preinit {
+		return
+	}
+
 	// For c-archive/c-shared this is called by libpreinit with
 	// preinit == true.
 	if (isarchive || islibrary) && !preinit {


### PR DESCRIPTION
Implementation of the cooperative runtimes.
Now the gosecure calls go through a dedicated channel between the two domains.
We also have support for any function signature for targets of the gosecure keyword.

The runtime has been modified to go and check for migrated routines that are blocked on cross domain structures. 